### PR TITLE
Compatibilidade com o ZSH

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -14,7 +14,8 @@ YELLOW='\e[0;33m'
 
 workon djangular3  # Muda isso pro nome do virtalenv do seu projeto
 
-export PROJ_BASE="$(dirname ${BASH_SOURCE[0]})"
+THIS_SCRIPT_PATH=$(readlink -f $0)
+export PROJ_BASE=$(dirname $THIS_SCRIPT_PATH)
 CD=$(pwd)
 cd $PROJ_BASE
 export PROJ_BASE=$(pwd)
@@ -179,7 +180,7 @@ function dorun {
     echo_green "STARTING $name ..."
     echo "$cmd"
     t1=$(now_milis)
-    $cmd
+    eval $cmd
     exitcode=$?
     t2=$(now_milis)
     delta_t=$(expr $t2 - $t1)

--- a/dev.sh
+++ b/dev.sh
@@ -16,10 +16,6 @@ workon djangular3  # Muda isso pro nome do virtalenv do seu projeto
 
 THIS_SCRIPT_PATH=$(readlink -f $0)
 export PROJ_BASE=$(dirname $THIS_SCRIPT_PATH)
-CD=$(pwd)
-cd $PROJ_BASE
-export PROJ_BASE=$(pwd)
-cd $CD
 
 #. ci/funcs.sh
 
@@ -65,84 +61,75 @@ function devhelp {
 }
 
 function pytests {
-    CD=$(pwd)
     cd $PROJ_BASE
     dorun "./manage.py test cameras" "Testes python"
     exitcode=$?
-    cd $CD
+    cd -
     return $exitcode
 }
 
 function djangorun {
-    CD=$(pwd)
     cd $PROJ_BASE
     dorun "./manage.py runserver" "Servidor django"
     exitcode=$?
-    cd $CD
+    cd -
     return $exitcode
 }
 
 function frontdev {
-    CD=$(pwd)
     cd $PROJ_BASE/frontend
     dorun "gulp dev $*" "Dev Build"
     exitcode=$?
-    cd $CD
+    cd -
     return $exitcode
 }
 
 function frontprodmock {
-    CD=$(pwd)
     cd $PROJ_BASE/frontend
     dorun "gulp prod --mock true $*" "Prod build with mock API"
     exitcode=$?
-    cd $CD
+    cd -
     return $exitcode
 }
 
 function frontprod {
-    CD=$(pwd)
     cd $PROJ_BASE/frontend
     dorun "gulp prod --mock false $*" "Prod build - real deal"
     exitcode=$?
-    cd $CD
+    cd -
     return $exitcode
 }
 
 function copy2www {
-    CCD=$(pwd)
     cd $PROJ_BASE/frontend
     frontprod
     mkdir -p ../cameras/static/
     cp -Rf dist/js dist/css ../cameras/static/
-    cd $CCD
+    cd -
     return $exitcode
 }
 
 function frontrun {
-    CD=$(pwd)
     cd $PROJ_BASE/frontend
     gulp runserver
     exitcode=$?
-    cd $CD
+    cd -
     return $exitcode
 }
 
 function runjshint {
-    CD=$(pwd)
     cd $PROJ_BASE/frontend
     dorun "gulp jshintall" "JS Hint"
     exitcode=$?
-    cd $CD
+    cd - > /dev/null
     return $exitcode
 }
 
 function jstests {
-    CD=$(pwd)
     cd $PROJ_BASE/frontend
     dorun "gulp test $*" "JS tests"
     exitcode=$?
-    cd $CD
+    cd -
     return $exitcode
 }
 

--- a/dev.sh
+++ b/dev.sh
@@ -14,7 +14,11 @@ YELLOW='\e[0;33m'
 
 workon djangular3  # Muda isso pro nome do virtalenv do seu projeto
 
-THIS_SCRIPT_PATH=$(readlink -f $0)
+if [ "${BASH_SOURCE}" -eq "" ]; then
+    THIS_SCRIPT_PATH=$(readlink -f ${(%):-%N})
+else
+    THIS_SCRIPT_PATH=$BASH_SOURCE
+fi
 export PROJ_BASE=$(dirname $THIS_SCRIPT_PATH)
 
 #. ci/funcs.sh
@@ -61,75 +65,75 @@ function devhelp {
 }
 
 function pytests {
-    cd $PROJ_BASE
+    pushd $PROJ_BASE
     dorun "./manage.py test cameras" "Testes python"
     exitcode=$?
-    cd -
+    popd
     return $exitcode
 }
 
 function djangorun {
-    cd $PROJ_BASE
+    pushd $PROJ_BASE
     dorun "./manage.py runserver" "Servidor django"
     exitcode=$?
-    cd -
+    popd
     return $exitcode
 }
 
 function frontdev {
-    cd $PROJ_BASE/frontend
+    pushd $PROJ_BASE/frontend
     dorun "gulp dev $*" "Dev Build"
     exitcode=$?
-    cd -
+    popd
     return $exitcode
 }
 
 function frontprodmock {
-    cd $PROJ_BASE/frontend
+    pushd $PROJ_BASE/frontend
     dorun "gulp prod --mock true $*" "Prod build with mock API"
     exitcode=$?
-    cd -
+    popd
     return $exitcode
 }
 
 function frontprod {
-    cd $PROJ_BASE/frontend
+    pushd $PROJ_BASE/frontend
     dorun "gulp prod --mock false $*" "Prod build - real deal"
     exitcode=$?
-    cd -
+    popd
     return $exitcode
 }
 
 function copy2www {
-    cd $PROJ_BASE/frontend
+    pushd $PROJ_BASE/frontend
     frontprod
     mkdir -p ../cameras/static/
     cp -Rf dist/js dist/css ../cameras/static/
-    cd -
+    popd
     return $exitcode
 }
 
 function frontrun {
-    cd $PROJ_BASE/frontend
+    pushd $PROJ_BASE/frontend
     gulp runserver
     exitcode=$?
-    cd -
+    popd
     return $exitcode
 }
 
 function runjshint {
-    cd $PROJ_BASE/frontend
+    pushd $PROJ_BASE/frontend
     dorun "gulp jshintall" "JS Hint"
     exitcode=$?
-    cd - > /dev/null
+    popd
     return $exitcode
 }
 
 function jstests {
-    cd $PROJ_BASE/frontend
+    pushd $PROJ_BASE/frontend
     dorun "gulp test $*" "JS tests"
     exitcode=$?
-    cd -
+    popd
     return $exitcode
 }
 


### PR DESCRIPTION
A variável BASH_SOURCE não tava disponível no meu shell (ZSH). E dentro
da função `dorun` havia uma execução de algo guardado em variável ($cmd)
que sem o eval também não funciona no ZSH.

Espero não ter quebrado nada no Bash ... :stuck_out_tongue: 